### PR TITLE
fix recursive compression

### DIFF
--- a/tools/create_repository.py
+++ b/tools/create_repository.py
@@ -397,8 +397,8 @@ def main():
     parser.add_argument(
         '--datadir',
         '-d',
-        default='.',
-        help='Path to place the add-ons [current directory]')
+        default='output',
+        help='Path to place the add-ons [./output directory]')
     parser.add_argument(
         '--info',
         '-i',


### PR DESCRIPTION
If --datadir is not specified, it uses the current directory as the target directory and causes a .zip file to be created equal to the amount of free space on the partition.